### PR TITLE
Parser fixes and issues documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,14 @@ See [examples](./examples_test.go) and [tests](./config_test.go).
 ## Testing and QA tools for development
 
 See [Makefile](./Makefile) and [VS Code setup](.vscode).
+
+## Known issues
+
+- In some cases, quoted values are not parsed correctly.
+```
+MULTILINE_QUOTED="this is a multiline
+quoted
+value"
+
+QUOTED_INCLUDING_QUOTES="{ \"name\": \"John\", \"age\": 30 }"
+```

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -89,6 +89,13 @@ func (p *Parser) Parse(r io.Reader, vars map[string]string) error {
 		case err != nil:
 			return err
 
+		case p.stream.isAtEqualSign():
+			// If equal sign detected, start reading variable value (`name=VALUE #comment`).
+			if p.atToken(valueToken) {
+				p.tokens.value.append(p.stream.current)
+			}
+			p.setToken(valueToken)
+
 		case p.stream.isAtCommentBegin():
 			// Comment begins (`name=value #COMMENT`), save last variable.
 			if p.atToken(valueToken) {
@@ -106,13 +113,6 @@ func (p *Parser) Parse(r io.Reader, vars map[string]string) error {
 		case p.atToken(commentToken):
 			// If inside a comment, just skip to next rune.
 			continue
-
-		case p.stream.isAtEqualSign():
-			// If equal sign detected, start reading variable value (`name=VALUE #comment`).
-			if p.atToken(valueToken) {
-				p.tokens.value.append(p.stream.current)
-			}
-			p.setToken(valueToken)
 
 		case p.atToken(nameToken):
 			// Read variable name ignoring spaces (`NAME=value #comment`).

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -112,7 +112,6 @@ func (p *Parser) Parse(r io.Reader, vars map[string]string) error {
 
 		case p.atToken(commentToken):
 			// If inside a comment, just skip to next rune.
-			continue
 
 		case p.atToken(nameToken):
 			// Read variable name ignoring spaces (`NAME=value #comment`).

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -83,9 +83,12 @@ func TestParse(t *testing.T) {
 		"BIG",
 		"Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua",
 	)
-	// assertVar(t, vars, "Y", "this is \na weird \nmultiline\nvalue")
-	// FAILS:
-	// assertVar(t, vars, "LONG", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	assertVar(
+		t,
+		vars,
+		"LONG",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	)
 	assertVar(t, vars, "Z1", "12345")
 	assertVar(t, vars, "Z2", "0")
 	assertVar(t, vars, "Z3", "-999")
@@ -106,6 +109,7 @@ func TestParse(t *testing.T) {
 	assertVar(t, vars, "EMPTY2", "")
 	assertVar(t, vars, "NUM_STRING", "12345")
 	// FAILS: assertVar(t, vars, "BROKEN_NEWLINE", "this is\nstill valid because quotes stay open")
+	// FAILS: assertVar(t, vars, "BROKEN_NEWLINE_SINGLE_QUOTES", "this is\nstill valid because quotes stay open")
 	assertVar(t, vars, "XX", "second")
 	assertVar(t, vars, "INTERPOLATED", "\\$B env_$A $ \\$B \\\\$C ${REDIS_PORT} + $")
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -32,7 +32,7 @@ func TestParse(t *testing.T) {
 		t.Error("expected no error")
 	}
 
-	expectedNumberOfVars := 66 // IS THIS OK?
+	expectedNumberOfVars := 67 // IS THIS OK?
 	if len(vars) != expectedNumberOfVars {
 		t.Fatalf("Expected %d vars, got %d", expectedNumberOfVars, len(vars))
 	}
@@ -62,6 +62,7 @@ func TestParse(t *testing.T) {
 	assertVar(t, vars, "POS_NUM", "+1")
 	assertVar(t, vars, "POS_NOT_NUM", "++1")
 	// FAILS: assertVar(t, vars, "O", "#notacomment")
+	assertVar(t, vars, "O2", "")
 	assertVar(t, vars, "P", "key=value=another")
 	assertVar(t, vars, "Q", "$UNDEFINED_VAR")
 	assertVar(t, vars, "R", "$A-$B-$C")
@@ -83,7 +84,8 @@ func TestParse(t *testing.T) {
 		"Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua",
 	)
 	// assertVar(t, vars, "Y", "this is \na weird \nmultiline\nvalue")
-	// FAILS: assertVar(t, vars, "LONG", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	// FAILS:
+	// assertVar(t, vars, "LONG", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	assertVar(t, vars, "Z1", "12345")
 	assertVar(t, vars, "Z2", "0")
 	assertVar(t, vars, "Z3", "-999")

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -32,7 +32,7 @@ func TestParse(t *testing.T) {
 		t.Error("expected no error")
 	}
 
-	expectedNumberOfVars := 65 // IS THIS OK?
+	expectedNumberOfVars := 66 // IS THIS OK?
 	if len(vars) != expectedNumberOfVars {
 		t.Fatalf("Expected %d vars, got %d", expectedNumberOfVars, len(vars))
 	}
@@ -41,7 +41,7 @@ func TestParse(t *testing.T) {
 	assertVar(t, vars, "B", "$A")
 	assertVar(t, vars, "BB", "CC")
 	assertVar(t, vars, "VAR_WITH_COMMENT", "val with comment")
-	// FAILS: assertVar(t, vars, "D", "")
+	assertVar(t, vars, "D", "")
 	assertVar(t, vars, "D2", "")
 	assertVar(t, vars, "D3", "")
 	assertVar(t, vars, "E", "some value with spaces")
@@ -61,7 +61,7 @@ func TestParse(t *testing.T) {
 	assertVar(t, vars, "NOT_NUM", "---1")
 	assertVar(t, vars, "POS_NUM", "+1")
 	assertVar(t, vars, "POS_NOT_NUM", "++1")
-	// FAILS: assertEqual(t, vars["O"], "#notacomment")
+	// FAILS: assertVar(t, vars, "O", "#notacomment")
 	assertVar(t, vars, "P", "key=value=another")
 	assertVar(t, vars, "Q", "$UNDEFINED_VAR")
 	assertVar(t, vars, "R", "$A-$B-$C")
@@ -82,8 +82,8 @@ func TestParse(t *testing.T) {
 		"BIG",
 		"Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua",
 	)
-	// FAILS: assertEqual(t, vars["Y"], "this is \na weird \nmultiline\nvalue")
-	// FAILS: assertEqual(t, vars["LONG"], "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	// assertVar(t, vars, "Y", "this is \na weird \nmultiline\nvalue")
+	// FAILS: assertVar(t, vars, "LONG", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	assertVar(t, vars, "Z1", "12345")
 	assertVar(t, vars, "Z2", "0")
 	assertVar(t, vars, "Z3", "-999")
@@ -96,14 +96,14 @@ func TestParse(t *testing.T) {
 	assertVar(t, vars, "EE", "[this looks like json]")
 	assertVar(t, vars, "EE2", "[this looks like json]")
 	assertVar(t, vars, "EE3", "[this looks like json]")
-	// IS THIS OK? assertEqual(t, vars["EE4"], "[this looks like json]")
-	// IS THIS OK? assertEqual(t, vars["EE5"], "[this looks like json]")
-	// FAILS: assertEqual(t, vars["FF"], "{ \"name\": \"John\", \"age\": 30 }")
+	// IS THIS OK? assertVar(t, vars, "EE4", "[this looks like json]")
+	// IS THIS OK? assertVar(t, vars, "EE5", "[this looks like json]")
+	// FAILS: assertVar(t, vars, "FF", "{ \"name\": \"John\", \"age\": 30 }")
 	assertVar(t, vars, "ARRAY", "one,two,three")
 	assertVar(t, vars, "EMPTY1", "")
 	assertVar(t, vars, "EMPTY2", "")
 	assertVar(t, vars, "NUM_STRING", "12345")
-	// FAILS: assertEqual(t, vars["BROKEN_NEWLINE"], "this is\nstill valid because quotes stay open")
+	// FAILS: assertVar(t, vars, "BROKEN_NEWLINE", "this is\nstill valid because quotes stay open")
 	assertVar(t, vars, "XX", "second")
 	assertVar(t, vars, "INTERPOLATED", "\\$B env_$A $ \\$B \\\\$C ${REDIS_PORT} + $")
 }

--- a/internal/parser/testdata/.env
+++ b/internal/parser/testdata/.env
@@ -47,6 +47,7 @@ POS_NOT_NUM =++1
 
 # Value starting with #
 O="#notacomment"
+O2=#notacomment"
 
 # Equals sign inside value
 P="key=value=another"

--- a/internal/parser/testdata/.env
+++ b/internal/parser/testdata/.env
@@ -94,12 +94,6 @@ X4=1
 # Large value
 BIG=Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua
 
-# Weird multiline value inside quotes
-Y="this is 
-a weird 
-multiline
-value"
-
 # Very long line without breaks
 LONG=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
@@ -144,9 +138,11 @@ EMPTY2=''
 # Numbers inside quotes (still string)
 NUM_STRING="12345"
 
-# Quotes but newline inside quotes
+# Quoted multiline
 BROKEN_NEWLINE="this is
 still valid because quotes stay open"
+BROKEN_NEWLINE_SINGLE_QUOTES='this is
+still valid because quotes stay open'
 
 # Overwrite
 XX=first


### PR DESCRIPTION
* Start scan with equal sign (fixes empty var not being parsed)
* Document known issues for quoted values